### PR TITLE
fixedkeymap no longer depends on ordereddict

### DIFF
--- a/maps/fixedkeymap.py
+++ b/maps/fixedkeymap.py
@@ -1,9 +1,8 @@
-import collections
 import collections.abc
 
 class FixedKeyMap(collections.abc.MutableMapping):
     def __init__(self, *args, **kwargs):
-        self._data = collections.OrderedDict(*args, **kwargs)
+        self._data = dict(*args, **kwargs)
 
     def __getitem__(self, name):
         return self._data[name]

--- a/maps/namedfixedkeymap.py
+++ b/maps/namedfixedkeymap.py
@@ -1,4 +1,5 @@
 import abc
+import collections
 import maps.utils as utils
 from maps.fixedkeymap import FixedKeyMap
 
@@ -43,10 +44,13 @@ class NamedFixedKeyMapMeta(abc.ABCMeta):
         # handle custom __init__
         template = '\n'.join([
             'def __init__(self, {args}):',
-            '    super(type(self), self).__init__({kwargs})'])
+            '    super(type(self), self).__init__()',
+            '    self._data = collections.OrderedDict({kwargs})'])
         args = ', '.join(fields)
         kwargs = ', '.join([f'{i}={i}' for i in fields])
-        exec(template.format(args=args, kwargs=kwargs), methods)
+        namespace = {'collections': collections}
+        exec(template.format(args=args, kwargs=kwargs), namespace)
+        methods['__init__'] = namespace['__init__']
 
         return super().__new__(cls, typename, (FixedKeyMap,), methods)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='maps',
-    version='3.1.0',
+    version='4.0.0',
     description='Maps: flavors of Python dictionaries',
     url='https://github.com/pcattori/maps',
     author='Pedro Cattori',


### PR DESCRIPTION
namedfixedkeymap injects ordereddict dependency (now more similar to namedfrozenmap)
major version bump in case people depend on ordering of fixedkeymap items